### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/layers/Legacy/Schema/packages/everythingelse-wp/README.md
+++ b/layers/Legacy/Schema/packages/everythingelse-wp/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/everythingelse/README.md
+++ b/layers/Legacy/Schema/packages/everythingelse/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/highlights-wp/README.md
+++ b/layers/Legacy/Schema/packages/highlights-wp/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/highlights/README.md
+++ b/layers/Legacy/Schema/packages/highlights/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/notifications-wp/README.md
+++ b/layers/Legacy/Schema/packages/notifications-wp/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/notifications/README.md
+++ b/layers/Legacy/Schema/packages/notifications/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/stances-wp/README.md
+++ b/layers/Legacy/Schema/packages/stances-wp/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Schema/packages/stances/README.md
+++ b/layers/Legacy/Schema/packages/stances/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Wassup/packages/everythingelse-mutations/README.md
+++ b/layers/Legacy/Wassup/packages/everythingelse-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Legacy/Wassup/packages/wassup/README.md
+++ b/layers/Legacy/Wassup/packages/wassup/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/application-wp/README.md
+++ b/layers/SiteBuilder/packages/application-wp/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/application/README.md
+++ b/layers/SiteBuilder/packages/application/README.md
@@ -170,7 +170,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/component-model-configuration/README.md
+++ b/layers/SiteBuilder/packages/component-model-configuration/README.md
@@ -540,7 +540,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/definitionpersistence/README.md
+++ b/layers/SiteBuilder/packages/definitionpersistence/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/definitions-base36/README.md
+++ b/layers/SiteBuilder/packages/definitions-base36/README.md
@@ -54,7 +54,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/definitions-emoji/README.md
+++ b/layers/SiteBuilder/packages/definitions-emoji/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/multisite/README.md
+++ b/layers/SiteBuilder/packages/multisite/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/resourceloader/README.md
+++ b/layers/SiteBuilder/packages/resourceloader/README.md
@@ -192,7 +192,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/resources/README.md
+++ b/layers/SiteBuilder/packages/resources/README.md
@@ -192,7 +192,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/site-wp/README.md
+++ b/layers/SiteBuilder/packages/site-wp/README.md
@@ -55,7 +55,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/site/README.md
+++ b/layers/SiteBuilder/packages/site/README.md
@@ -192,7 +192,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/spa/README.md
+++ b/layers/SiteBuilder/packages/spa/README.md
@@ -55,7 +55,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/SiteBuilder/packages/static-site-generator/README.md
+++ b/layers/SiteBuilder/packages/static-site-generator/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/comment-mutations/README.md
+++ b/layers/Wassup/packages/comment-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/contactus-mutations/README.md
+++ b/layers/Wassup/packages/contactus-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/contactuser-mutations/README.md
+++ b/layers/Wassup/packages/contactuser-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/custompost-mutations/README.md
+++ b/layers/Wassup/packages/custompost-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/custompostlink-mutations/README.md
+++ b/layers/Wassup/packages/custompostlink-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/event-mutations/README.md
+++ b/layers/Wassup/packages/event-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/eventlink-mutations/README.md
+++ b/layers/Wassup/packages/eventlink-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/flag-mutations/README.md
+++ b/layers/Wassup/packages/flag-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/form-mutations/README.md
+++ b/layers/Wassup/packages/form-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/gravityforms-mutations/README.md
+++ b/layers/Wassup/packages/gravityforms-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/highlight-mutations/README.md
+++ b/layers/Wassup/packages/highlight-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/location-mutations/README.md
+++ b/layers/Wassup/packages/location-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/locationpost-mutations/README.md
+++ b/layers/Wassup/packages/locationpost-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/locationpostlink-mutations/README.md
+++ b/layers/Wassup/packages/locationpostlink-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/locationposts-wp/README.md
+++ b/layers/Wassup/packages/locationposts-wp/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/locationposts/README.md
+++ b/layers/Wassup/packages/locationposts/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/newsletter-mutations/README.md
+++ b/layers/Wassup/packages/newsletter-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/notification-mutations/README.md
+++ b/layers/Wassup/packages/notification-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/post-mutations/README.md
+++ b/layers/Wassup/packages/post-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/postlink-mutations/README.md
+++ b/layers/Wassup/packages/postlink-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/share-mutations/README.md
+++ b/layers/Wassup/packages/share-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/socialnetwork-mutations/README.md
+++ b/layers/Wassup/packages/socialnetwork-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/stance-mutations/README.md
+++ b/layers/Wassup/packages/stance-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/system-mutations/README.md
+++ b/layers/Wassup/packages/system-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/user-state-mutations/README.md
+++ b/layers/Wassup/packages/user-state-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style

--- a/layers/Wassup/packages/volunteer-mutations/README.md
+++ b/layers/Wassup/packages/volunteer-mutations/README.md
@@ -56,7 +56,7 @@ composer preview-code-downgrade
 
 [PSR-1](https://www.php-fig.org/psr/psr-1), [PSR-4](https://www.php-fig.org/psr/psr-4) and [PSR-12](https://www.php-fig.org/psr/psr-12).
 
-To check the coding standards via [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer), run:
+To check the coding standards via [PHP CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), run:
 
 ``` bash
 composer check-style


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The \`squizlabs/PHP_CodeSniffer\` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932

---

**Note:** I am not familiar with this repository and am not sure if updating all the URLs across the 49 package READMEs this way is the correct approach.